### PR TITLE
Updated needed dependencies to fit map.apps 4.20.0+ package names

### DIFF
--- a/src/main/js/bundles/dn_bookmarks/BookmarksModel.js
+++ b/src/main/js/bundles/dn_bookmarks/BookmarksModel.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Bookmark from "esri/webmap/Bookmark";
-import BookmarksViewModel from "esri/widgets/Bookmarks/BookmarksViewModel";
-import Collection from "esri/core/Collection";
+import Bookmark from "@arcgis/core/webmap/Bookmark";
+import BookmarksViewModel from "@arcgis/core/widgets/Bookmarks/BookmarksViewModel";
+import Collection from "@arcgis/core/core/Collection";
 
 export default BookmarksViewModel.createSubclass({
     _localStorage: window.localStorage,

--- a/src/main/js/bundles/dn_bookmarks/manifest.json
+++ b/src/main/js/bundles/dn_bookmarks/manifest.json
@@ -10,11 +10,11 @@
     "icon": {},
     "productName": "devnet-mapapps-bookmarks",
     "dependencies": {
-        "esri": "^4.21.0",
-        "esri-widgets": "^4.11.0",
-        "apprt-vue": "^4.11.0",
-        "apprt-vuetify": "^4.11.0",
-        "map-widget": "^4.11.0"
+        "@arcgis/core": "~4.33.14",
+        "esri-widgets": "^4.20.0",
+        "apprt-vue": "^4.20.0",
+        "apprt-vuetify": "^4.20.0",
+        "map-widget": "^4.20.0"
     },
     "CSS-Themes-Extension": [
         {


### PR DESCRIPTION
This is a first version to get this bundle working with map.apps 4.20.0+. Starting with map.apps 4.20.0+ the imported packages use another namespace, so imports needs to be updated.
``esri/**" --> arcgis/core/**``

@sholtkamp What is the best way to create the needed PR? Do you prefer a have a "full" project update including the whole project setup or do you update dev-bundles in a "bulk-change"?